### PR TITLE
[fix] modify bash path to abusolute

### DIFF
--- a/bin/termux-send-line
+++ b/bin/termux-send-line
@@ -1,4 +1,4 @@
-#!bash
+#!/data/data/com.termux/files/usr/bin/bash
 if [ -p /dev/stdin ]; then
     input=$(cat)
 else


### PR DESCRIPTION
```shell
#!bash
```

だと

```
bash: bad interpreter: No such file or directory
```

というエラーが出てしまうので

```shell
#!/data/data/com.termux/files/usr/bin/bash
```

と絶対パスに修正しました。